### PR TITLE
Implement MkDocs multi-site pipeline with custom tags plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+obsidian-vault/published/
+*.pyc
+
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# MK-Docs-Obsidian-
+# Theophysics MkDocs Pipeline
+
+This repository converts David Lowe's Obsidian vault into three
+independent MkDocs sites that ship to the existing Cloudflare Pages
+projects:
+
+- `theophysics.pages.dev` – curated production research
+- `theophysics-template.pages.dev` – full research vault
+- `theophysics-blog.pages.dev` – AI collaboration template
+
+The automation replaces the earlier static HTML exporter with a
+frontmatter-driven pipeline that honours selective publishing, advanced
+markdown extensions, and multimedia content.
+
+## Quick Start
+
+1. Place the Obsidian vault in `obsidian-vault/` (the sample content is a
+   working reference).
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Build the MkDocs projects:
+
+   ```bash
+   python automation/website-deployment/mkdocs-pipeline/build.py --verbose
+   ```
+
+4. Deploy using the existing scripts in
+   `obsidian-vault/automation/website-deployment`.
+
+## Frontmatter Schema
+
+Every note may declare:
+
+```yaml
+---
+publish_to:
+  production: true
+  research: true
+  template: false
+title: "Custom Title"
+description: "Short SEO description"
+author: "David Lowe"
+date: "2025-01-15"
+tags: [quantum, consciousness]
+category: research
+audio_file:
+  - assets/audio/sample.mp3
+video_file: assets/video/session.mp4
+image_gallery:
+  - assets/images/fig-1.png
+  - assets/images/fig-2.png
+toc_depth: 3
+math: true
+comments: true
+---
+```
+
+Notes default to `research: true` when the `publish_to` block is absent.
+Audio, video, and gallery entries automatically produce styled players
+and copy the referenced media into the build output.
+
+## Pipeline Highlights
+
+- Lantana-inspired custom theme layered on MkDocs Material with Terminal
+  UI elements.
+- PyMdown extensions, KaTeX/MathJax, syntax highlighting, tags, macros,
+  awesome-pages, git revision metadata, and HTML/CSS minification.
+- `[[wikilinks]]` are converted to Markdown links using an index of vault
+  documents and attachments.
+- Built-in `tags` plugin (packaged locally) generates tag indexes and exposes
+  tag metadata to templates.
+- Generated navigation scaffold for `Home`, `Tags`, `Research`, `AI
+  Collab`, `Data`, and `Tools` sections.
+- Audio playlist enhancer with download controls, plus responsive video
+  and image galleries.
+
+## Testing & Deployment
+
+Run the included build script locally; the resulting MkDocs projects are
+written to `obsidian-vault/published/<site>` and are ready for `mkdocs
+build` or the Cloudflare deployment pipeline.
+
+See `docs/index.md` for full usage notes and integration guidance.

--- a/automation/website-deployment/mkdocs-pipeline/README.md
+++ b/automation/website-deployment/mkdocs-pipeline/README.md
@@ -1,0 +1,12 @@
+# Theophysics MkDocs Pipeline Package
+
+This package exposes the custom `tags` plugin used by the multi-site
+MkDocs deployment as well as helper utilities that are bundled with the
+repository.  Install it locally via:
+
+```bash
+pip install -e automation/website-deployment/mkdocs-pipeline
+```
+
+The plugin is registered under the `mkdocs.plugins` entry point so it can
+be referenced simply as `tags` within `mkdocs.yml`.

--- a/automation/website-deployment/mkdocs-pipeline/assets/javascripts/audio-controls.js
+++ b/automation/website-deployment/mkdocs-pipeline/assets/javascripts/audio-controls.js
@@ -1,0 +1,52 @@
+(function () {
+  function initPlaylist(group) {
+    var players = group.querySelectorAll('audio');
+    var items = group.querySelectorAll('.audio-playlist li');
+    if (!players.length || !items.length) {
+      return;
+    }
+
+    function activate(index) {
+      items.forEach(function (item, itemIndex) {
+        if (itemIndex === index) {
+          item.classList.add('is-active');
+        } else {
+          item.classList.remove('is-active');
+        }
+      });
+    }
+
+    items.forEach(function (item, index) {
+      item.addEventListener('click', function () {
+        var player = players[index];
+        if (!player) return;
+        players.forEach(function (other) {
+          if (other !== player) {
+            other.pause();
+          }
+        });
+        player.currentTime = 0;
+        player.play();
+        activate(index);
+      });
+    });
+
+    players.forEach(function (player, index) {
+      player.addEventListener('play', function () {
+        activate(index);
+      });
+      player.addEventListener('ended', function () {
+        var nextIndex = (index + 1) % players.length;
+        if (nextIndex !== index) {
+          players[nextIndex].play();
+        }
+      });
+    });
+
+    activate(0);
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.audio-player-group').forEach(initPlaylist);
+  });
+})();

--- a/automation/website-deployment/mkdocs-pipeline/assets/javascripts/mathjax.js
+++ b/automation/website-deployment/mkdocs-pipeline/assets/javascripts/mathjax.js
@@ -1,0 +1,18 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$', '$$'], ['\\[', '\\]']]
+  },
+  options: {
+    renderActions: {
+      addMenu: []
+    }
+  }
+};
+
+(function () {
+  var script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js';
+  document.head.appendChild(script);
+})();

--- a/automation/website-deployment/mkdocs-pipeline/assets/javascripts/terminal-effects.js
+++ b/automation/website-deployment/mkdocs-pipeline/assets/javascripts/terminal-effects.js
@@ -1,0 +1,49 @@
+(function () {
+  function ensureHeaderMeta() {
+    var header = document.querySelector('.md-header');
+    if (!header || document.querySelector('.tp-header-meta')) {
+      return;
+    }
+    var meta = document.createElement('div');
+    meta.className = 'tp-header-meta';
+    var terminal = document.createElement('div');
+    terminal.className = 'tp-header-terminal';
+    var prompt = document.createElement('span');
+    prompt.className = 'prompt';
+    var siteKind = document.body.getAttribute('data-site-kind') || 'site';
+    prompt.textContent = siteKind + '@theophysics';
+    var separator = document.createElement('span');
+    separator.className = 'separator';
+    separator.textContent = '$';
+    var command = document.createElement('span');
+    command.className = 'command';
+    var tagline = document.body.getAttribute('data-site-tagline') || document.title;
+    command.textContent = tagline;
+    terminal.appendChild(prompt);
+    terminal.appendChild(separator);
+    terminal.appendChild(command);
+    meta.appendChild(terminal);
+    header.parentNode.insertBefore(meta, header.nextSibling);
+  }
+
+  function updateClock() {
+    var terminal = document.querySelector('.tp-header-terminal');
+    if (!terminal) return;
+    var existing = terminal.querySelector('.timestamp');
+    if (!existing) {
+      existing = document.createElement('span');
+      existing.className = 'timestamp';
+      existing.style.marginLeft = '0.6rem';
+      existing.style.color = 'var(--tp-muted)';
+      terminal.appendChild(existing);
+    }
+    var now = new Date();
+    existing.textContent = now.toISOString().slice(0, 19).replace('T', ' ');
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    ensureHeaderMeta();
+    updateClock();
+    setInterval(updateClock, 1000 * 30);
+  });
+})();

--- a/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/audio-player.css
+++ b/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/audio-player.css
@@ -1,0 +1,119 @@
+.audio-player-group {
+  background: rgba(18, 22, 32, 0.85);
+  border: 1px solid rgba(50, 200, 255, 0.2);
+  border-radius: 0.6rem;
+  padding: 1.2rem;
+  margin: 1.5rem 0;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.audio-player {
+  margin-bottom: 1.2rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: rgba(10, 12, 18, 0.9);
+  border: 1px solid rgba(125, 92, 255, 0.25);
+}
+
+.audio-player:last-child {
+  margin-bottom: 0;
+}
+
+audio {
+  width: 100%;
+}
+
+.audio-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.5rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.8rem;
+}
+
+.audio-download {
+  color: var(--tp-accent);
+  text-decoration: none;
+}
+
+.audio-download:hover {
+  color: var(--tp-accent-secondary);
+  text-decoration: underline;
+}
+
+.audio-info {
+  color: var(--tp-muted);
+}
+
+.audio-playlist {
+  margin-bottom: 1rem;
+}
+
+.audio-playlist ol {
+  list-style: none;
+  padding-left: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem;
+}
+
+.audio-playlist li {
+  background: rgba(16, 20, 32, 0.85);
+  border: 1px solid rgba(50, 200, 255, 0.2);
+  border-radius: 0.4rem;
+  padding: 0.6rem 0.8rem;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.audio-playlist li:hover, .audio-playlist li.is-active {
+  border-color: var(--tp-accent);
+  transform: translateY(-2px);
+}
+
+.video-gallery {
+  margin: 1.5rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.2rem;
+}
+
+.video-player {
+  background: rgba(10, 12, 18, 0.9);
+  border: 1px solid rgba(125, 92, 255, 0.25);
+  border-radius: 0.6rem;
+  padding: 1rem;
+}
+
+.video-player video {
+  width: 100%;
+  border-radius: 0.4rem;
+}
+
+.image-gallery {
+  margin: 1.5rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.gallery-item {
+  background: rgba(10, 12, 18, 0.9);
+  border: 1px solid rgba(50, 200, 255, 0.2);
+  border-radius: 0.6rem;
+  overflow: hidden;
+  text-align: center;
+}
+
+.gallery-item img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.gallery-item figcaption {
+  padding: 0.6rem 0.8rem;
+  font-size: 0.85rem;
+  color: var(--tp-muted);
+}

--- a/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/custom.css
+++ b/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/custom.css
@@ -1,0 +1,106 @@
+:root {
+  --tp-background: #0f111a;
+  --tp-surface: #161a24;
+  --tp-border: rgba(255, 255, 255, 0.08);
+  --tp-accent: #32c8ff;
+  --tp-accent-secondary: #7d5cff;
+  --tp-text: #f4f6fb;
+  --tp-muted: #9aa0b5;
+}
+
+body {
+  background-color: var(--tp-background);
+  color: var(--tp-text);
+}
+
+.md-header, .md-tabs {
+  background: linear-gradient(135deg, rgba(16, 20, 32, 0.95), rgba(22, 24, 34, 0.95));
+  border-bottom: 1px solid var(--tp-border);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.45);
+}
+
+.md-nav__title, .md-nav__item a {
+  color: var(--tp-muted);
+}
+
+.md-nav__item--active > a {
+  color: var(--tp-accent);
+}
+
+.md-footer {
+  background: rgba(10, 12, 18, 0.98);
+  border-top: 1px solid var(--tp-border);
+}
+
+.md-typeset a {
+  color: var(--tp-accent);
+}
+
+.md-typeset a:hover {
+  color: var(--tp-accent-secondary);
+}
+
+.md-typeset h1, .md-typeset h2, .md-typeset h3 {
+  color: var(--tp-text);
+  border-bottom: 1px solid rgba(50, 200, 255, 0.15);
+  padding-bottom: 0.3rem;
+}
+
+.md-typeset blockquote {
+  border-left: 4px solid var(--tp-accent-secondary);
+  background: rgba(125, 92, 255, 0.08);
+  color: var(--tp-text);
+}
+
+.md-search {
+  max-width: 26rem;
+}
+
+.tp-header-meta {
+  background: rgba(7, 9, 14, 0.85);
+  border-top: 1px solid var(--tp-border);
+  border-bottom: 1px solid var(--tp-border);
+  padding: 0.35rem 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.tp-header-terminal {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  color: var(--tp-accent);
+  letter-spacing: 0.03em;
+}
+
+.tp-header-terminal .separator {
+  color: var(--tp-muted);
+  margin: 0 0.4rem;
+}
+
+.tp-header-terminal .command {
+  color: var(--tp-text);
+}
+
+.md-grid {
+  max-width: 1200px;
+}
+
+.md-typeset code {
+  background: rgba(16, 20, 32, 0.9);
+  color: #e7f5ff;
+  border: 1px solid rgba(50, 200, 255, 0.15);
+}
+
+.md-typeset pre > code {
+  border-radius: 0.4rem;
+}
+
+.md-typeset hr {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+@media screen and (max-width: 720px) {
+  .tp-header-terminal {
+    font-size: 0.75rem;
+  }
+}

--- a/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/terminal-overrides.css
+++ b/automation/website-deployment/mkdocs-pipeline/assets/stylesheets/terminal-overrides.css
@@ -1,0 +1,44 @@
+.terminal-alert {
+  border-left: 4px solid var(--tp-accent);
+  background: rgba(12, 16, 26, 0.9);
+  padding: 0.8rem 1rem;
+  margin: 1.2rem 0;
+  border-radius: 0.4rem;
+  box-shadow: inset 0 0 0 1px rgba(50, 200, 255, 0.15);
+}
+
+.terminal-alert-error {
+  border-left-color: #ff6b6b;
+  box-shadow: inset 0 0 0 1px rgba(255, 107, 107, 0.35);
+}
+
+.terminal-alert-primary {
+  border-left-color: #7d5cff;
+  box-shadow: inset 0 0 0 1px rgba(125, 92, 255, 0.35);
+}
+
+.terminal-alert > .admonition-title {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--tp-accent-secondary);
+}
+
+.terminal-alert > .admonition-title::before {
+  margin-right: 0.4rem;
+}
+
+.md-typeset .admonition.terminal-alert p {
+  color: var(--tp-text);
+}
+
+.md-typeset .admonition.terminal-alert code {
+  border: none;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.md-typeset .admonition.terminal-alert a {
+  color: var(--tp-accent);
+  text-decoration: underline;
+}

--- a/automation/website-deployment/mkdocs-pipeline/build.py
+++ b/automation/website-deployment/mkdocs-pipeline/build.py
@@ -1,0 +1,937 @@
+#!/usr/bin/env python3
+"""MkDocs pipeline for Theophysics Research Platform.
+
+This script transforms an Obsidian vault into three themed MkDocs
+projects (production, research, template).  Notes are filtered using the
+``publish_to`` frontmatter flag described in the technical specification
+and additional assets such as audio, video and image galleries are
+materialised automatically.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import re
+import shutil
+import sys
+import posixpath
+from pathlib import Path, PurePosixPath
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+LOGGER = logging.getLogger("mkdocs_pipeline")
+
+
+PUBLISH_TARGETS = ("production", "research", "template")
+DEFAULT_PUBLISH_TARGET = "research"
+MARKDOWN_SUFFIXES = {".md", ".markdown"}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+@dataclasses.dataclass
+class Note:
+    """Representation of an Obsidian markdown document."""
+
+    source_path: Path
+    relative_path: Path
+    metadata: Mapping[str, object]
+    body: str
+
+    @property
+    def stem(self) -> str:
+        return self.source_path.stem
+
+
+@dataclasses.dataclass
+class SiteConfig:
+    """Configuration for a single MkDocs site."""
+
+    identifier: str
+    site_name: str
+    site_description: str
+    site_url: str
+    output_dir: Path
+    palette_accent: str
+    palette_primary: str
+    extra: Mapping[str, object]
+
+
+BASE_THEME_CONFIG: Mapping[str, object] = {
+    "name": "material",
+    "custom_dir": "theme/lantana-terminal",
+    "language": "en",
+    "palette": [
+        {
+            "scheme": "slate",
+            "primary": "black",
+            "accent": "cyan",
+        }
+    ],
+    "features": [
+        "navigation.tabs",
+        "navigation.sections",
+        "navigation.top",
+        "search.highlight",
+        "search.share",
+        "toc.integrate",
+    ],
+}
+
+
+MARKDOWN_EXTENSIONS: Sequence[object] = [
+    "pymdownx.caret",
+    "pymdownx.mark",
+    "pymdownx.tilde",
+    "pymdownx.snippets",
+    "pymdownx.superfences",
+    "pymdownx.highlight",
+    "pymdownx.inlinehilite",
+    {
+        "pymdownx.blocks.details": {
+            "types": [
+                {
+                    "name": "info",
+                    "class": "terminal-alert",
+                    "title": "Info",
+                },
+                {
+                    "name": "warning",
+                    "class": "terminal-alert terminal-alert-error",
+                    "title": "Warning",
+                },
+                {
+                    "name": "important",
+                    "class": "terminal-alert terminal-alert-primary",
+                    "title": "Important",
+                },
+            ]
+        }
+    },
+    "def_list",
+    "footnotes",
+    "tables",
+    "toc",
+    "attr_list",
+    "md_in_html",
+    {"pymdownx.arithmatex": {"generic": True}},
+]
+
+
+PLUGINS: Sequence[object] = [
+    'search',
+    'tags',
+    'awesome-pages',
+    'git-revision-date',
+    {'macros': {'include_dir': 'macros'}},
+    {'minify': {'minify_html': True, 'minify_js': True, 'minify_css': True}},
+]
+
+NAVIGATION: Sequence[Mapping[str, object]] = [
+    {"Home": "index.md"},
+    {"Tags": "tags.md"},
+    {"Research": "research/index.md"},
+    {"AI Collab": "ai-collab/index.md"},
+    {"Data": "data/index.md"},
+    {"Tools": "tools/index.md"},
+]
+
+SITE_MATRIX: Mapping[str, SiteConfig] = {
+    "production": SiteConfig(
+        identifier="production",
+        site_name="Theophysics Research Platform",
+        site_description="Curated highlights from the Theophysics research archive",
+        site_url="https://theophysics.pages.dev",
+        output_dir=Path("production"),
+        palette_accent="cyan",
+        palette_primary="black",
+        extra={
+            "site_kind": "production",
+            "tagline": "Curated publications for the Quantum-Consciousness community",
+        },
+    ),
+    "research": SiteConfig(
+        identifier="research",
+        site_name="Theophysics Research Vault",
+        site_description="Complete working vault for internal and collaborative studies",
+        site_url="https://theophysics-template.pages.dev",
+        output_dir=Path("research"),
+        palette_accent="teal",
+        palette_primary="black",
+        extra={
+            "site_kind": "research",
+            "tagline": "Full-stack knowledge base for David Lowe and collaborators",
+        },
+    ),
+    "template": SiteConfig(
+        identifier="template",
+        site_name="Theophysics Collaboration Lab",
+        site_description="Template site showcasing AI collaboration workflows",
+        site_url="https://theophysics-blog.pages.dev",
+        output_dir=Path("template"),
+        palette_accent="purple",
+        palette_primary="black",
+        extra={
+            "site_kind": "template",
+            "tagline": "Experimental frontier for AI-augmented research",
+        },
+    ),
+}
+
+EXCLUDED_DIRECTORIES = {
+    "automation",
+    "published",
+    ".obsidian",
+    "environment",
+}
+
+PAGE_FRONTMATTER_KEYS = (
+    "title",
+    "description",
+    "author",
+    "date",
+    "tags",
+    "category",
+    "toc_depth",
+    "math",
+    "comments",
+)
+
+WIKILINK_PATTERN = re.compile(r"(!)?\[\[([^\]]+)\]\]")
+
+
+class PipelineError(RuntimeError):
+    """Domain specific error raised by the pipeline."""
+
+
+@dataclasses.dataclass
+class VaultIndex:
+    """Index of documents and media used for wikilink resolution."""
+
+    documents: Mapping[str, Path]
+    assets: Mapping[str, Path]
+    raw_documents: Mapping[str, Path]
+    raw_assets: Mapping[str, Path]
+
+
+@dataclasses.dataclass
+class RenderContext:
+    """Context for rendering a single markdown document."""
+
+    site: SiteConfig
+    vault_root: Path
+    docs_dir: Path
+    index: VaultIndex
+
+
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build all MkDocs projects from the Obsidian vault")
+    parser.add_argument(
+        "--vault",
+        type=Path,
+        default=Path("obsidian-vault"),
+        help="Path to the Obsidian vault root (default: obsidian-vault)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("obsidian-vault/published"),
+        help="Directory where the MkDocs sites will be generated",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove previously generated files before building",
+    )
+    parser.add_argument(
+        "--site",
+        choices=PUBLISH_TARGETS,
+        help="Build only the given site identifier",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(verbose: bool = False) -> None:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+    LOGGER.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def parse_front_matter(text: str) -> Tuple[Mapping[str, object], str]:
+    if not text.startswith("---"):
+        return {}, text
+
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return {}, text
+
+    closing_index: Optional[int] = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing_index = index
+            break
+
+    if closing_index is None:
+        return {}, text
+
+    frontmatter_block = "\n".join(lines[1:closing_index])
+    body = "\n".join(lines[closing_index + 1 :])
+
+    try:
+        metadata = yaml.safe_load(frontmatter_block) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive logging
+        LOGGER.warning("Failed to parse YAML front matter: %s", exc)
+        metadata = {}
+
+    if not isinstance(metadata, dict):
+        LOGGER.debug("Front matter was not a mapping; ignoring")
+        metadata = {}
+
+    return metadata, body.lstrip("\n")
+
+
+def normalise_component(value: str) -> str:
+    slug = re.sub(r"[\s_]+", "-", value.strip().lower())
+    slug = re.sub(r"[^a-z0-9\-\/]+", "", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    return slug.strip("-")
+
+
+def normalise_path(value: str) -> str:
+    value = value.replace("\\", "/")
+    parts = [normalise_component(part) for part in value.split("/") if part]
+    return "/".join(part for part in parts if part)
+
+
+def gather_vault(vault_root: Path) -> Tuple[List[Note], List[Tuple[Path, Path]]]:
+    notes: List[Note] = []
+    assets: List[Tuple[Path, Path]] = []
+
+    for path in vault_root.rglob("*"):
+        if path.is_dir():
+            continue
+        try:
+            rel_path = path.relative_to(vault_root)
+        except ValueError:
+            continue
+        if rel_path.parts and rel_path.parts[0] in EXCLUDED_DIRECTORIES:
+            continue
+
+        if path.suffix.lower() in MARKDOWN_SUFFIXES:
+            metadata, body = parse_front_matter(read_text(path))
+            notes.append(Note(path, rel_path.with_suffix(".md"), metadata, body))
+        else:
+            assets.append((path, rel_path))
+
+    notes.sort(key=lambda note: note.relative_path.as_posix())
+    assets.sort(key=lambda item: item[1].as_posix())
+    return notes, assets
+
+
+def build_index(notes: Sequence[Note], assets: Sequence[Tuple[Path, Path]]) -> VaultIndex:
+    document_map: Dict[str, Path] = {}
+    asset_map: Dict[str, Path] = {}
+    raw_documents: Dict[str, Path] = {}
+    raw_assets: Dict[str, Path] = {}
+
+    for note in notes:
+        relative_without_suffix = note.relative_path.with_suffix("")
+        normalised_with_dirs = normalise_path(relative_without_suffix.as_posix())
+        normalised_stem = normalise_component(note.stem)
+
+        title = note.metadata.get("title") if isinstance(note.metadata, Mapping) else None
+        if title:
+            normalised_title = normalise_component(str(title))
+        else:
+            normalised_title = None
+
+        for key in {normalised_with_dirs, normalised_stem, normalised_title}:
+
+            if key and key not in document_map:
+                document_map[key] = note.relative_path
+                raw_documents[key] = note.relative_path
+
+    for asset_path, rel_path in assets:
+        relative_without_suffix = rel_path.with_suffix("")
+        normalised_with_dirs = normalise_path(relative_without_suffix.as_posix())
+        normalised_name = normalise_component(rel_path.name)
+        normalised_filename = normalise_component(rel_path.stem)
+
+        for key in {normalised_with_dirs, normalised_name, normalised_filename}:
+            if key and key not in asset_map:
+                asset_map[key] = rel_path
+                raw_assets[key] = rel_path
+
+    return VaultIndex(document_map, asset_map, raw_documents, raw_assets)
+
+
+def as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "on", "1"}
+    return bool(value)
+
+
+def determine_publish_targets(metadata: Mapping[str, object]) -> Mapping[str, bool]:
+    publish_to = metadata.get("publish_to")
+    results: Dict[str, bool] = {target: False for target in PUBLISH_TARGETS}
+
+    if publish_to is None:
+        results[DEFAULT_PUBLISH_TARGET] = True
+        return results
+
+    if isinstance(publish_to, Mapping):
+        for key, value in publish_to.items():
+            if key in results:
+                results[key] = as_bool(value)
+        return results
+
+    if isinstance(publish_to, Sequence) and not isinstance(publish_to, (str, bytes)):
+        for item in publish_to:
+            if isinstance(item, str) and item in results:
+                results[item] = True
+        return results
+
+    if as_bool(publish_to):
+        results[DEFAULT_PUBLISH_TARGET] = True
+        return results
+
+    return results
+
+
+def resolve_wikilink(
+    target: str,
+    doc_map: Mapping[str, Path],
+    asset_map: Mapping[str, Path],
+) -> Optional[Tuple[Path, bool]]:
+    anchor = ""
+    if "#" in target:
+        base, _, anchor = target.partition("#")
+    else:
+        base = target
+
+    base = base.strip()
+    normalised_target = normalise_path(base)
+    normalised_with_suffix = normalise_path(base.rstrip(".md"))
+
+    for key in filter(None, [normalised_target, normalised_with_suffix]):
+        if key in doc_map:
+            path = doc_map[key]
+            return (path.with_suffix(".md"), True)
+
+    for key in filter(None, [normalised_target, normalised_with_suffix]):
+        if key in asset_map:
+            return (asset_map[key], False)
+
+    return None
+
+
+def format_wikilink(
+    match: re.Match[str],
+    context: RenderContext,
+    note: Note,
+) -> str:
+    is_embed = bool(match.group(1))
+    raw_target = match.group(2)
+    alias = None
+    target = raw_target
+    anchor = ""
+
+    if "|" in raw_target:
+        target, alias = raw_target.split("|", 1)
+    if "#" in target:
+        target, _, anchor = target.partition("#")
+    target = target.strip()
+
+    resolved = resolve_wikilink(target, context.index.documents, context.index.assets)
+    if not resolved:
+        LOGGER.debug("Unresolved wikilink '%s' in %s", raw_target, note.relative_path)
+        return match.group(0)
+
+    relative_path, is_document = resolved
+    note_dir = PurePosixPath(note.relative_path).parent
+    start = note_dir.as_posix() if str(note_dir) not in {"", "."} else "."
+    href = posixpath.relpath(relative_path.as_posix(), start=start)
+    if href == ".":
+        href = relative_path.name
+    if anchor:
+        href = f"{href}#{normalise_component(anchor)}"
+
+    link_text = alias or target
+
+    if is_embed:
+        suffix = relative_path.suffix.lower()
+        if suffix in IMAGE_EXTENSIONS:
+            return f"![{link_text}]({href})"
+        return f"[{link_text}]({href})"
+
+    return f"[{link_text}]({href})"
+
+
+def convert_wikilinks(text: str, context: RenderContext, note: Note) -> str:
+    return WIKILINK_PATTERN.sub(lambda match: format_wikilink(match, context, note), text)
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def render_frontmatter(metadata: Mapping[str, object]) -> str:
+    page_meta: Dict[str, object] = {}
+    for key in PAGE_FRONTMATTER_KEYS:
+        if key in metadata and metadata[key] is not None:
+            page_meta[key] = metadata[key]
+
+    if not page_meta:
+        return ""
+
+    dumped = yaml.safe_dump(page_meta, sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{dumped}\n---\n\n"
+
+
+def coerce_list(value: object) -> List[object]:
+    if value is None:
+        return []
+    if isinstance(value, (str, Path)):
+        return [value]
+    if isinstance(value, Sequence):
+        return list(value)
+    return [value]
+
+
+def mime_type_for(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        return "audio/mpeg"
+    if suffix == ".wav":
+        return "audio/wav"
+    if suffix == ".m4a":
+        return "audio/mp4"
+    if suffix == ".ogg":
+        return "audio/ogg"
+    if suffix == ".mp4":
+        return "video/mp4"
+    if suffix == ".webm":
+        return "video/webm"
+    if suffix == ".mov":
+        return "video/quicktime"
+    if suffix == ".mkv":
+        return "video/x-matroska"
+    if suffix == ".m4v":
+        return "video/x-m4v"
+    return "application/octet-stream"
+
+
+def copy_asset(vault_root: Path, docs_dir: Path, relative_path: Path) -> Path:
+    destination = docs_dir / relative_path
+    ensure_directory(destination.parent)
+    shutil.copy2(vault_root / relative_path, destination)
+    return relative_path
+
+
+def render_audio_blocks(
+    metadata: Mapping[str, object],
+    note: Note,
+    context: RenderContext,
+) -> Tuple[str, List[Path]]:
+    audio_value = metadata.get("audio_file")
+    if not audio_value:
+        return "", []
+
+    entries: List[Dict[str, object]] = []
+    for raw_item in coerce_list(audio_value):
+        if isinstance(raw_item, Mapping):
+            sources = [Path(str(v)) for v in coerce_list(raw_item.get("sources") or raw_item.values())]
+            title = raw_item.get("title") or raw_item.get("name") or note.stem
+        else:
+            sources = [Path(str(raw_item))]
+            title = Path(str(raw_item)).stem
+        entries.append({"title": str(title), "sources": sources})
+
+    rendered_blocks: List[str] = []
+    copied_assets: List[Path] = []
+    playlist_items: List[str] = []
+
+    for index, entry in enumerate(entries, start=1):
+        sources_markup: List[str] = []
+        download_href: Optional[str] = None
+        for source in entry["sources"]:
+            resolved = resolve_media_path(source, note, context)
+            if resolved is None:
+                LOGGER.warning("Audio source %s not found for %s", source, note.relative_path)
+                continue
+            copied_assets.append(resolved)
+            mime = mime_type_for(resolved)
+            href = resolved.as_posix()
+            sources_markup.append(f'    <source src="{href}" type="{mime}">')
+            if download_href is None:
+                download_href = href
+
+        if not sources_markup:
+            continue
+
+        title = entry["title"] or f"Track {index}"
+        playlist_items.append(f'<li data-track="{index}">{title}</li>')
+
+        controls = ""
+        if download_href:
+            controls = (
+                "<div class=\"audio-controls\">"
+                f"<a class=\"audio-download\" href=\"{download_href}\" download>Download</a>"
+                f"<span class=\"audio-info\">{title}</span>"
+                "</div>"
+            )
+
+        block = (
+            "<div class=\"audio-player\">\n"
+            "  <audio controls preload=\"metadata\">\n"
+            + "\n".join(sources_markup)
+            + "\n    Your browser does not support the audio element.\n  </audio>\n"
+            + f"  {controls}\n"
+            + "</div>\n"
+        )
+        rendered_blocks.append(block)
+
+    if not rendered_blocks:
+        return "", copied_assets
+
+    playlist_markup = ""
+    if len(rendered_blocks) > 1:
+        playlist_markup = (
+            "<div class=\"audio-playlist\">\n"
+            "  <h3>Playlist</h3>\n  <ol>\n"
+            + "\n".join(f"    {item}" for item in playlist_items)
+            + "\n  </ol>\n</div>\n"
+        )
+
+    wrapper = (
+        "<section class=\"audio-player-group\">\n"
+        + playlist_markup
+        + "\n".join(rendered_blocks)
+        + "</section>\n\n"
+    )
+
+    return wrapper, copied_assets
+
+
+def resolve_media_path(path: Path, note: Note, context: RenderContext) -> Optional[Path]:
+    absolute_candidate = None
+    if path.is_absolute():
+        absolute_candidate = path
+    else:
+        relative_to_note = (note.source_path.parent / path).resolve()
+        if relative_to_note.exists():
+            absolute_candidate = relative_to_note
+        else:
+            vault_candidate = (context.vault_root / path).resolve()
+            if vault_candidate.exists():
+                absolute_candidate = vault_candidate
+
+    if absolute_candidate is None or not absolute_candidate.exists():
+        return None
+
+    relative_path = absolute_candidate.relative_to(context.vault_root)
+    copy_asset(context.vault_root, context.docs_dir, relative_path)
+    return relative_path
+
+
+def render_video_block(
+    metadata: Mapping[str, object],
+    note: Note,
+    context: RenderContext,
+) -> Tuple[str, List[Path]]:
+    video_value = metadata.get("video_file")
+    if not video_value:
+        return "", []
+
+    rendered: List[str] = []
+    copied: List[Path] = []
+
+    for raw_path in coerce_list(video_value):
+        resolved = resolve_media_path(Path(str(raw_path)), note, context)
+        if resolved is None:
+            LOGGER.warning("Video source %s not found for %s", raw_path, note.relative_path)
+            continue
+        mime = mime_type_for(resolved)
+        copied.append(resolved)
+        rendered.append(
+            "<div class=\"video-player\">\n"
+            "  <video controls preload=\"metadata\">\n"
+            f"    <source src=\"{resolved.as_posix()}\" type=\"{mime}\">\n"
+            "    Your browser does not support the video tag.\n  </video>\n"
+            "</div>\n"
+        )
+
+    if not rendered:
+        return "", copied
+
+    return "<section class=\"video-gallery\">\n" + "\n".join(rendered) + "</section>\n\n", copied
+
+
+def render_image_gallery(
+    metadata: Mapping[str, object],
+    note: Note,
+    context: RenderContext,
+) -> Tuple[str, List[Path]]:
+    gallery_value = metadata.get("image_gallery")
+    if not gallery_value:
+        return "", []
+
+    items: List[str] = []
+    copied: List[Path] = []
+
+    for raw_path in coerce_list(gallery_value):
+        resolved = resolve_media_path(Path(str(raw_path)), note, context)
+        if resolved is None:
+            LOGGER.warning("Gallery image %s not found for %s", raw_path, note.relative_path)
+            continue
+        copied.append(resolved)
+        alt_text = Path(str(raw_path)).stem.replace("-", " ").replace("_", " ")
+        items.append(
+            "  <figure class=\"gallery-item\">\n"
+            f"    <img src=\"{resolved.as_posix()}\" alt=\"{alt_text}\">\n"
+            f"    <figcaption>{alt_text.title()}</figcaption>\n  </figure>"
+        )
+
+    if not items:
+        return "", copied
+
+    return "<section class=\"image-gallery\">\n" + "\n".join(items) + "\n</section>\n\n", copied
+
+
+def render_note(note: Note, context: RenderContext) -> str:
+    metadata = note.metadata or {}
+    frontmatter = render_frontmatter(metadata)
+    wiki_converted = convert_wikilinks(note.body, context, note)
+
+    audio_html, _ = render_audio_blocks(metadata, note, context)
+    video_html, _ = render_video_block(metadata, note, context)
+    gallery_html, _ = render_image_gallery(metadata, note, context)
+
+    body_parts = [audio_html, video_html, gallery_html, wiki_converted]
+    body = "".join(part for part in body_parts if part)
+    return frontmatter + body
+
+
+def copy_theme_assets(site_dir: Path) -> None:
+    theme_source = Path(__file__).resolve().parent / "theme" / "lantana-terminal"
+    destination = site_dir / "theme" / "lantana-terminal"
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(theme_source, destination)
+
+
+def copy_static_assets(site_dir: Path) -> None:
+    assets_source = Path(__file__).resolve().parent / "assets"
+    docs_dir = site_dir / "docs"
+    ensure_directory(docs_dir)
+
+    for asset in assets_source.rglob("*"):
+        if asset.is_dir():
+            continue
+        relative = asset.relative_to(assets_source)
+        destination = docs_dir / relative
+        ensure_directory(destination.parent)
+        shutil.copy2(asset, destination)
+
+
+def write_site_metadata_script(site_dir: Path, site: SiteConfig) -> None:
+    docs_dir = site_dir / "docs"
+    js_dir = docs_dir / "javascripts"
+    ensure_directory(js_dir)
+    if isinstance(site.extra, Mapping):
+        site_kind = site.extra.get('site_kind', site.identifier)
+        tagline = site.extra.get('tagline', site.site_description)
+    else:
+        site_kind = site.identifier
+        tagline = site.site_description
+    script = (
+        "(function(){\n"
+        "  document.addEventListener('DOMContentLoaded', function () {\n"
+        "    var body = document.body;\n"
+        f"    body.setAttribute('data-site-kind', {json.dumps(site_kind)});\n"
+        f"    body.setAttribute('data-site-tagline', {json.dumps(tagline)});\n"
+        "  });\n"
+        "})();\n"
+    )
+    (js_dir / 'site-meta.js').write_text(script, encoding='utf-8')
+
+
+def copy_macros(site_dir: Path) -> None:
+    macros_source = Path(__file__).resolve().parent / "templates" / "macros"
+    macros_destination = site_dir / "macros"
+    if macros_destination.exists():
+        shutil.rmtree(macros_destination)
+    shutil.copytree(macros_source, macros_destination)
+
+
+def ensure_navigation_scaffolding(site_dir: Path) -> None:
+    docs_dir = site_dir / "docs"
+    placeholders = {
+        Path("research/index.md"): "# Research Library\n\nCurated research collections appear here.",
+        Path("ai-collab/index.md"): "# AI Collaboration\n\nDocument experiments and AI-assisted workflows.",
+        Path("data/index.md"): "# Data Archives\n\nDatasets and analysis artefacts live in this section.",
+        Path("tools/index.md"): "# Tools\n\nScripts, automations, and helpers for research teams.",
+        Path("tags.md"): "# Tags\n\n{% raw %}{{ tags }}{% endraw %}",
+    }
+
+    for relative_path, contents in placeholders.items():
+        destination = docs_dir / relative_path
+        if destination.exists():
+            continue
+        ensure_directory(destination.parent)
+        destination.write_text(contents + "\n", encoding="utf-8")
+
+    index_path = docs_dir / "index.md"
+    if not index_path.exists():
+        index_contents = (
+            "# Welcome to the Theophysics Research Platform\n\n"
+            "This site was generated automatically from the Obsidian vault. "
+            "Replace this file with your own introduction by adding an `index.md` "
+            "note to the vault root.\n"
+        )
+        index_path.write_text(index_contents, encoding="utf-8")
+
+
+def build_mkdocs_config(site: SiteConfig) -> Mapping[str, object]:
+    palette = [{"scheme": "slate", "primary": site.palette_primary, "accent": site.palette_accent}]
+    theme_config = dict(BASE_THEME_CONFIG)
+    theme_config["palette"] = palette
+
+    config: Dict[str, object] = {
+        "site_name": site.site_name,
+        "site_description": site.site_description,
+        "site_author": "David Lowe",
+        "site_url": site.site_url,
+        "theme": theme_config,
+        "markdown_extensions": MARKDOWN_EXTENSIONS,
+        "plugins": list(PLUGINS),
+        "nav": list(NAVIGATION),
+        "extra": dict(site.extra),
+        "extra_css": [
+            "stylesheets/custom.css",
+            "stylesheets/audio-player.css",
+            "stylesheets/terminal-overrides.css",
+        ],
+        "extra_javascript": [
+            "javascripts/site-meta.js",
+            "javascripts/mathjax.js",
+            "javascripts/audio-controls.js",
+            "javascripts/terminal-effects.js",
+        ],
+    }
+
+    return config
+
+
+def write_mkdocs_config(site_dir: Path, config: Mapping[str, object]) -> None:
+    mkdocs_yml = site_dir / "mkdocs.yml"
+    with mkdocs_yml.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(config, stream, sort_keys=False, allow_unicode=True)
+
+
+def write_note(note: Note, site_dir: Path, context: RenderContext) -> None:
+    docs_dir = site_dir / "docs"
+    destination = docs_dir / note.relative_path
+    ensure_directory(destination.parent)
+    rendered = render_note(note, context)
+    destination.write_text(rendered, encoding="utf-8")
+
+
+def copy_remaining_assets(site_dir: Path, assets: Sequence[Tuple[Path, Path]]) -> None:
+    docs_dir = site_dir / "docs"
+    for source, relative in assets:
+        destination = docs_dir / relative
+        ensure_directory(destination.parent)
+        shutil.copy2(source, destination)
+
+
+def build_site(
+    site: SiteConfig,
+    vault_root: Path,
+    output_root: Path,
+    notes: Sequence[Note],
+    assets: Sequence[Tuple[Path, Path]],
+    index: VaultIndex,
+) -> None:
+    site_dir = output_root / site.output_dir
+    LOGGER.info("Building site '%s' in %s", site.identifier, site_dir)
+    ensure_directory(site_dir)
+    docs_dir = site_dir / "docs"
+    if docs_dir.exists():
+        shutil.rmtree(docs_dir)
+    ensure_directory(docs_dir)
+
+    copy_theme_assets(site_dir)
+    copy_static_assets(site_dir)
+    write_site_metadata_script(site_dir, site)
+    copy_macros(site_dir)
+
+    context = RenderContext(site, vault_root, docs_dir, index)
+
+    for note in notes:
+        publish_flags = determine_publish_targets(note.metadata)
+        if not publish_flags.get(site.identifier, False):
+            continue
+        write_note(note, site_dir, context)
+
+    copy_remaining_assets(site_dir, assets)
+    ensure_navigation_scaffolding(site_dir)
+    mkdocs_config = build_mkdocs_config(site)
+    write_mkdocs_config(site_dir, mkdocs_config)
+
+
+def clean_output(output_root: Path, site: Optional[str]) -> None:
+    targets = [SITE_MATRIX[site]] if site else SITE_MATRIX.values()
+    for config in targets:
+        site_dir = output_root / config.output_dir
+        if site_dir.exists():
+            LOGGER.info("Cleaning %s", site_dir)
+            shutil.rmtree(site_dir)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_arguments(argv)
+    configure_logging(args.verbose)
+
+    vault_root = args.vault.resolve()
+    output_root = args.output.resolve()
+
+    if not vault_root.exists():
+        raise PipelineError(f"Vault path {vault_root} does not exist")
+
+    ensure_directory(output_root)
+
+    if args.clean:
+        clean_output(output_root, args.site)
+
+    notes, assets = gather_vault(vault_root)
+    if not notes:
+        LOGGER.warning("No markdown notes found in %s", vault_root)
+
+    index = build_index(notes, assets)
+
+    targets = [SITE_MATRIX[args.site]] if args.site else SITE_MATRIX.values()
+
+    for site in targets:
+        build_site(site, vault_root, output_root, notes, assets, index)
+
+    LOGGER.info("MkDocs build configuration generated successfully")
+    LOGGER.info("Output available in %s", output_root)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/automation/website-deployment/mkdocs-pipeline/mkdocs_pipeline/tags.py
+++ b/automation/website-deployment/mkdocs-pipeline/mkdocs_pipeline/tags.py
@@ -1,0 +1,110 @@
+"""Custom MkDocs plugin for generating tag indexes."""
+from __future__ import annotations
+
+import posixpath
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Dict, Iterable, List, Mapping
+
+import yaml
+from mkdocs.config import config_options
+from mkdocs.plugins import BasePlugin
+
+
+def _parse_front_matter(path: Path) -> Mapping[str, object]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return {}
+    closing_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing_index = index
+            break
+    if closing_index is None:
+        return {}
+    block = "\n".join(lines[1:closing_index])
+    try:
+        metadata = yaml.safe_load(block) or {}
+    except yaml.YAMLError:
+        return {}
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _as_list(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Iterable):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _page_title(metadata: Mapping[str, object], fallback: str) -> str:
+    title = metadata.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return fallback
+
+
+def _relative_path(path: Path, root: Path) -> PurePosixPath:
+    return PurePosixPath(path.relative_to(root).as_posix())
+
+
+def _relpath(target: PurePosixPath, origin: PurePosixPath) -> str:
+    start = origin.as_posix() if origin.as_posix() not in {"", "."} else "."
+    return posixpath.relpath(target.as_posix(), start=start)
+
+
+class TagsPlugin(BasePlugin):
+    """Lightweight tag index generator."""
+
+    config_scheme = (
+        ("tags_page", config_options.Type(str, default="tags.md")),
+        ("title", config_options.Type(str, default="Tags")),
+    )
+
+    def on_config(self, config):
+        docs_dir = Path(config["docs_dir"]).resolve()
+        tag_map: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+        for path in docs_dir.rglob("*.md"):
+            metadata = _parse_front_matter(path)
+            tags = _as_list(metadata.get("tags"))
+            if not tags:
+                continue
+            relative = _relative_path(path, docs_dir)
+            title = _page_title(metadata, relative.stem.replace("-", " ").title())
+            entry = {"title": title, "relative": relative}
+            for tag in tags:
+                name = str(tag).strip()
+                if name:
+                    tag_map[name].append(entry)
+
+        for entries in tag_map.values():
+            entries.sort(key=lambda item: item["title"].lower())
+
+        self._tag_index = dict(sorted(tag_map.items(), key=lambda item: item[0].lower()))
+        config["extra"].setdefault("tag_index", self._tag_index)
+        return config
+
+    def on_page_markdown(self, markdown, page, config, files):
+        if page.file.src_path != self.config["tags_page"]:
+            return markdown
+
+        source = PurePosixPath(page.file.src_path)
+        lines = [f"# {self.config['title']}"]
+        if not self._tag_index:
+            lines.append("No tags available yet. Add `tags` to your note frontmatter.")
+            return "\n\n".join(lines) + "\n"
+
+        for tag, entries in self._tag_index.items():
+            lines.append(f"## {tag}")
+            for entry in entries:
+                href = _relpath(entry["relative"], source.parent)
+                lines.append(f"- [{entry['title']}]({href})")
+            lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"

--- a/automation/website-deployment/mkdocs-pipeline/pyproject.toml
+++ b/automation/website-deployment/mkdocs-pipeline/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=62"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "theophysics-mkdocs-pipeline"
+version = "0.1.0"
+description = "MkDocs build helpers for the Theophysics research platform"
+authors = [{ name = "David Lowe" }]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = ["pyyaml>=6.0"]
+
+[project.entry-points."mkdocs.plugins"]
+tags = "mkdocs_pipeline.tags:TagsPlugin"

--- a/automation/website-deployment/mkdocs-pipeline/setup.cfg
+++ b/automation/website-deployment/mkdocs-pipeline/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = theophysics-mkdocs-pipeline
+version = 0.1.0
+
+[options]
+packages = find:
+include_package_data = True
+install_requires = pyyaml>=6.0
+
+[options.entry_points]
+mkdocs.plugins =
+    tags = mkdocs_pipeline.tags:TagsPlugin

--- a/automation/website-deployment/mkdocs-pipeline/templates/macros/main.py
+++ b/automation/website-deployment/mkdocs-pipeline/templates/macros/main.py
@@ -1,0 +1,34 @@
+"""Custom macros for the Theophysics MkDocs deployments."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping
+
+
+def define_env(env):
+    """Register macros used within the documentation set."""
+
+    site_config = env.conf or {}
+    extra: Mapping[str, Any] = site_config.get("extra", {}) if isinstance(site_config, Mapping) else {}
+
+    def site_tagline(default: str = "") -> str:
+        return extra.get("tagline") or default
+
+    def render_timestamp(value: str | None = None, fmt: str = "%Y-%m-%d") -> str:
+        if not value:
+            return ""
+        try:
+            parsed = datetime.fromisoformat(value)
+            return parsed.strftime(fmt)
+        except ValueError:
+            return value
+
+    env.macro(site_tagline)
+    env.macro(render_timestamp)
+
+    env.variables.update(
+        {
+            "build_timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%SZ"),
+            "site_kind": extra.get("site_kind", "site"),
+        }
+    )

--- a/automation/website-deployment/mkdocs-pipeline/theme/lantana-terminal/mkdocs_theme.yml
+++ b/automation/website-deployment/mkdocs-pipeline/theme/lantana-terminal/mkdocs_theme.yml
@@ -1,0 +1,4 @@
+extends: material
+name: lantana-terminal
+static_templates:
+  - 404.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,52 @@
----
-share: true
-title: "THEOPHYSICS Research Hub"
----
+# Theophysics MkDocs Pipeline
 
-# THEOPHYSICS Research Hub
+This repository provides a complete automation stack for generating three
+independent MkDocs sites from a single Obsidian vault.  The solution is
+optimised for David Lowe's research workflow and mirrors the live
+Cloudflare Pages deployment (`theophysics.pages.dev`,
+`theophysics-template.pages.dev`, `theophysics-blog.pages.dev`).
 
-## Welcome to Breakthrough Physics Research
+## Key Features
 
-This research hub documents groundbreaking discoveries in the intersection of quantum mechanics, consciousness studies, and biblical prophecy.
+- YAML frontmatter controls which notes are published to each site.
+- Lantana-inspired dark theme blended with Terminal UI accents.
+- Advanced markdown support including PyMdown extensions and callouts.
+- HTML5 audio/video embedding with playlists and download links.
+- Automatic conversion of `[[wikilinks]]` and attachment management.
+- Macros, search, tags, and minified output for every generated site.
 
-## Key Research Areas
+## Repository Structure
 
-### 🔬 THEOPHYSICS Framework
-Dual-domain physics exploring the interface between General Relativity (Order) and Quantum Mechanics (Chaos).
+```text
+obsidian-vault/
+├── research-notes/           # Source markdown notes from Obsidian
+├── templates/                # Optional Obsidian templates
+├── automation/               # Existing deployment logic
+└── published/                # MkDocs build targets (generated)
+```
 
-### 🧠 Quantum-Consciousness Interface
-Evidence-based research on consciousness as a quantum phenomenon, building on PEAR Laboratory's 6σ statistical evidence.
+Automation assets live under
+`automation/website-deployment/mkdocs-pipeline` and include the builder,
+custom theme overrides, and static assets.
 
-### 📖 Biblical Prophecy Correlation
-Rigorous analysis showing statistical correlation between quantum decoherence acceleration and biblical prophecy timelines.
+## Usage
 
----
+```bash
+python automation/website-deployment/mkdocs-pipeline/build.py --verbose
+```
 
-*"The boundary between physics and metaphysics is dissolving, revealing a deeper unity underlying all reality."*
+The command scans the vault, materialises three MkDocs projects inside
+`obsidian-vault/published/`, and preserves the directory layout expected
+by the Cloudflare Pages deployments.
 
-**David Carter** | THEOPHYSICS Research | Oklahoma City, 2025
+Pass `--site production`, `--site research`, or `--site template` to
+build a single site.  Add `--clean` to remove previous builds.
+
+## Next Steps
+
+1. Copy your live Obsidian vault into `obsidian-vault/`.
+2. Adjust the site metadata in `build.py` if URLs or palettes change.
+3. Run the build script and then the existing deployment workflow under
+   `obsidian-vault/automation/website-deployment`.
+4. Customise CSS/JS in `automation/website-deployment/mkdocs-pipeline` as
+   needed for further branding.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,35 +1,26 @@
-site_name: THEOPHYSICS Research Hub
-site_description: "David Carter's breakthrough research on Quantum-Consciousness-Prophecy interface"
-site_author: David Carter
-site_url: https://mk-docs-obsidian-.pages.dev/
+site_name: Theophysics MkDocs Pipeline
+site_description: "Automation for multi-site MkDocs publishing from an Obsidian vault"
+site_author: David Lowe
+site_url: https://theophysics.pages.dev/
 
 theme:
   name: material
+  language: en
   palette:
-    - scheme: default
-      primary: blue
-      accent: blue
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
     - scheme: slate
-      primary: blue
-      accent: blue
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+      primary: indigo
+      accent: cyan
   features:
-    - navigation.instant
-    - navigation.tabs
-    - navigation.sections
     - navigation.top
-    - search.highlight
-    - toc.integrate
+    - navigation.tabs
+    - content.code.copy
 
 markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
   - toc:
       permalink: true
   - pymdownx.arithmatex:
@@ -37,9 +28,6 @@ markdown_extensions:
 
 plugins:
   - search
-  - roamlinks
 
 nav:
-  - Home: index.md
-  - THEOPHYSICS: theophysics/
-  - About: about.md
+  - Overview: index.md

--- a/obsidian-vault/automation/website-deployment/README.md
+++ b/obsidian-vault/automation/website-deployment/README.md
@@ -1,0 +1,19 @@
+# MkDocs Deployment Integration
+
+The MkDocs pipeline outputs three ready-to-build projects into
+`../published/<site>`.  Existing Cloudflare Pages automation can invoke
+`mkdocs build` (or `mkdocs gh-deploy`) within each of these directories
+before uploading the generated `site/` folder.
+
+1. `../published/production`
+2. `../published/research`
+3. `../published/template`
+
+Each directory contains:
+
+- `mkdocs.yml` configured with the Lantana + Terminal theme.
+- `docs/` populated with filtered markdown and media assets.
+- `macros/` and theme overrides required for the custom look and feel.
+
+Invoke the build script prior to deployment to keep the published sites
+in sync with the Obsidian vault.

--- a/obsidian-vault/research-notes/ai-lab-notebook.md
+++ b/obsidian-vault/research-notes/ai-lab-notebook.md
@@ -1,0 +1,23 @@
+---
+publish_to:
+  production: false
+  research: true
+  template: true
+title: "AI Collaboration Log"
+description: "Working notes shared with AI collaborators"
+tags: [ai, collaboration]
+category: analysis
+comments: true
+---
+
+# AI Collaboration Log
+
+This log captures iterative experiments with large language models.
+
+## Session Outline
+
+1. Plan \(\rightarrow\) Execute \(\rightarrow\) Reflect
+2. Track prompts in `automation/website-deployment`
+3. Archive conclusions in [[Research Index]]
+
+> Recorded on {% raw %}{{ build_timestamp }}{% endraw %}.

--- a/obsidian-vault/research-notes/assets/audio/quantum-intro.mp3
+++ b/obsidian-vault/research-notes/assets/audio/quantum-intro.mp3
@@ -1,0 +1,1 @@
+Placeholder audio content

--- a/obsidian-vault/research-notes/assets/images/field-diagram.png
+++ b/obsidian-vault/research-notes/assets/images/field-diagram.png
@@ -1,0 +1,1 @@
+placeholder

--- a/obsidian-vault/research-notes/quantum-consciousness.md
+++ b/obsidian-vault/research-notes/quantum-consciousness.md
@@ -1,0 +1,36 @@
+---
+publish_to:
+  production: true
+  research: true
+  template: false
+title: "Quantum Consciousness Overview"
+description: "Core summary of the consciousness-field interface"
+author: "David Lowe"
+date: "2025-01-15"
+tags: [quantum, consciousness, overview]
+category: "research"
+audio_file:
+  - assets/audio/quantum-intro.mp3
+image_gallery:
+  - assets/images/field-diagram.png
+math: true
+---
+
+# Quantum Consciousness Overview
+
+The [[Unified Field Hypothesis]] connects classical theophysics with
+state-dependent consciousness experiments.  Key assumptions include the
+relationship between \( \psi \) collapse and sacred geometry.
+
+==Key findings== are summarised below.
+
+!!! info
+    Field resonance aligns with \( \alpha = 7.32 \times 10^{-3} \).
+
+```python
+#!python
+def collapse_wave(function, intent):
+    return function.entangle(intent).collapse()
+```
+
+More material can be found in the [[Research Index|Research Index]].

--- a/obsidian-vault/research-notes/research-index.md
+++ b/obsidian-vault/research-notes/research-index.md
@@ -1,0 +1,15 @@
+---
+publish_to:
+  production: true
+  research: true
+  template: true
+title: "Research Index"
+description: "Navigation hub for research topics"
+tags: [index]
+category: research
+---
+
+# Research Index
+
+- [[Quantum Consciousness Overview]]
+- [[Unified Field Hypothesis]]

--- a/obsidian-vault/research-notes/unified-field-hypothesis.md
+++ b/obsidian-vault/research-notes/unified-field-hypothesis.md
@@ -1,0 +1,22 @@
+---
+publish_to:
+  production: true
+  research: true
+  template: true
+title: "Unified Field Hypothesis"
+description: "Mathematical framing of the theophysics field"
+tags: [field, theory]
+category: theory
+---
+
+# Unified Field Hypothesis
+
+The unified field describes the bridge between classical electromagnetism
+and consciousness harmonics.  The governing relationship is expressed as
+
+$$
+\nabla \cdot \mathbf{E}_\theta = \rho_{\text{intentional}}
+$$
+
+Backlinks and references are automatically generated through the MkDocs
+pipeline.

--- a/obsidian-vault/templates/research-note-template.md
+++ b/obsidian-vault/templates/research-note-template.md
@@ -1,0 +1,25 @@
+---
+publish_to:
+  production: false
+  research: true
+  template: true
+title: ""
+description: ""
+author: "David Lowe"
+date: "{{date}}"
+tags: []
+category: research
+toc_depth: 3
+math: false
+audio_file: []
+image_gallery: []
+comments: false
+---
+
+# {{title}}
+
+## Abstract
+
+## Findings
+
+## Next Actions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-mkdocs>=1.5.0
-mkdocs-material>=9.0.0
+mkdocs>=1.6.0
 pymdown-extensions>=10.0.0
-mkdocs-roamlinks-plugin>=0.2.1
-mkdocs-mermaid2-plugin>=1.0.0
-mkdocs-callouts>=1.9.0
-mkdocs-glightbox>=0.3.4
+mkdocs-material>=9.5.0
+mkdocs-macros-plugin>=1.0.4
+mkdocs-awesome-pages-plugin>=2.9.2
+mkdocs-minify-plugin>=0.7.1
+mkdocs-git-revision-date-plugin>=0.3.2
+pyyaml>=6.0
+-e automation/website-deployment/mkdocs-pipeline


### PR DESCRIPTION
## Summary
- add a build pipeline that reads the Obsidian vault, filters notes via front matter, resolves wikilinks, copies media, and emits themed MkDocs projects for production, research, and template sites
- package a custom `tags` MkDocs plugin together with macros, theme overrides, and audio/video UX assets to deliver the required Lantana + Terminal look and advanced markdown behaviour
- document the workflow and include representative vault content showing publish controls, media metadata, and collaboration templates

## Testing
- python automation/website-deployment/mkdocs-pipeline/build.py --clean
- (cd obsidian-vault/published/production && mkdocs build)

------
https://chatgpt.com/codex/tasks/task_e_68d058c1a7bc8331b98b5ca5388da981